### PR TITLE
Fix data autocast issue

### DIFF
--- a/src/pyfreedb/__init__.py
+++ b/src/pyfreedb/__init__.py
@@ -1,3 +1,3 @@
 """PyFreeDB is a Python library that provides common and simple database abstractions on top of Google Sheets."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/src/pyfreedb/providers/google/auth/service_account.py
+++ b/src/pyfreedb/providers/google/auth/service_account.py
@@ -1,23 +1,17 @@
 from typing import Dict, List, Optional
 
-from google.auth.transport.requests import Request
 from google.oauth2 import service_account
 
 from .base import GoogleAuthClient
 
 
 class ServiceAccountGoogleAuthClient(GoogleAuthClient):
-    def __init__(self, creds: service_account.Credentials, populate_token: bool = True) -> None:
+    def __init__(self, creds: service_account.Credentials) -> None:
         """Initialise auth client instance to perform authentication using Service Account.
 
         Client is recommended to not instantiate this class directly, use `from_service_account_info` and
         `from_service_account_file` constructor instead.
         """
-
-        # Token will not be populated if we don't call refresh.
-        if populate_token:
-            creds.refresh(Request())
-
         self._creds = creds
 
     @classmethod

--- a/src/pyfreedb/providers/google/sheet/wrapper.py
+++ b/src/pyfreedb/providers/google/sheet/wrapper.py
@@ -142,7 +142,6 @@ class _GoogleSheetWrapper:
         url = "https://docs.google.com/spreadsheets/d/{}/gviz/tq".format(spreadsheet_id)
         r = requests.get(url=url, params=params, headers=headers)
         r.raise_for_status()
-        print(r.text)
         return self._convert_query_result(r.text)
 
     def _convert_query_result(self, response: str) -> List[List[Any]]:

--- a/src/pyfreedb/providers/google/sheet/wrapper.py
+++ b/src/pyfreedb/providers/google/sheet/wrapper.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List, Union
 
-import requests
+from google.auth.transport.requests import AuthorizedSession
 from googleapiclient.discovery import build
 
 from pyfreedb.providers.google.auth.base import GoogleAuthClient
@@ -18,8 +18,8 @@ class _GoogleSheetWrapper:
 
     def __init__(self, auth_client: GoogleAuthClient):
         service = build("sheets", "v4", credentials=auth_client.credentials())
-        self._auth_client = auth_client
         self._svc = service.spreadsheets()
+        self._authed_session = AuthorizedSession(auth_client.credentials())
 
     def create_spreadsheet(self, title: str) -> str:
         resp = self._svc.create(body={"properties": {"title": title}}).execute()
@@ -129,9 +129,6 @@ class _GoogleSheetWrapper:
         return results
 
     def query(self, spreadsheet_id: str, sheet_name: str, query: str, has_header: bool = True) -> List[List[Any]]:
-        auth_token = "Bearer " + self._auth_client.credentials().token
-        headers = {"contentType": "application/json", "Authorization": auth_token}
-
         params: Dict[str, Union[str, int]] = {
             "sheet": sheet_name,
             "tqx": "responseHandler:freeleh",
@@ -140,9 +137,14 @@ class _GoogleSheetWrapper:
         }
 
         url = "https://docs.google.com/spreadsheets/d/{}/gviz/tq".format(spreadsheet_id)
-        r = requests.get(url=url, params=params, headers=headers)
-        r.raise_for_status()
-        return self._convert_query_result(r.text)
+        response = self._authed_session.request(
+            "GET",
+            url,
+            headers={"Content-Type": "application/json"},
+            params=params,
+        )
+        response.raise_for_status()
+        return self._convert_query_result(response.text)
 
     def _convert_query_result(self, response: str) -> List[List[Any]]:
         # Remove the schema header -> freeleh({...}).

--- a/src/pyfreedb/row/gsheet.py
+++ b/src/pyfreedb/row/gsheet.py
@@ -129,8 +129,6 @@ class GoogleSheetRowStore(Generic[T]):
             # Sanity check to see whether we pass the correct type or not. If this step fails we will raise exception.
             setattr(dummy_object, key, value)
 
-
-
         return UpdateStmt(self, update_value)
 
     def delete(self) -> DeleteStmt[T]:

--- a/src/pyfreedb/row/gsheet.py
+++ b/src/pyfreedb/row/gsheet.py
@@ -120,9 +120,16 @@ class GoogleSheetRowStore(Generic[T]):
             >>> store.update({"name": "cat"}).execute()
             10
         """
-        for key in update_value:
+        dummy_object = self._object_cls()
+
+        for key, value in update_value.items():
             if key not in self._object_cls._fields:
                 raise ValueError(f"{key} field is not recognised.")
+
+            # Sanity check to see whether we pass the correct type or not. If this step fails we will raise exception.
+            setattr(dummy_object, key, value)
+
+
 
         return UpdateStmt(self, update_value)
 

--- a/src/pyfreedb/row/models.py
+++ b/src/pyfreedb/row/models.py
@@ -36,14 +36,19 @@ class _Field(Generic[T]):
 
     def __set__(self, obj: Any, value: Optional[T]) -> None:
         self.__ensure_type(value)
-        return setattr(obj._data, self._field_name, value)
+        return setattr(obj._data, self._field_name, self._typ(value))
 
     def __ensure_type(self, value: Any) -> None:
         if value is None or value is NotSet:
             return
 
-        if not isinstance(value, self._typ):
-            raise TypeError(f"value of field {self._field_name} has the wrong type")
+        if self._typ is int or self._typ is float and isinstance(value, (int, float)):
+            return
+
+        if isinstance(value, self._typ):
+            return
+
+        raise TypeError(f"value of field {self._field_name} has the wrong type")
 
 
 class IntegerField(_Field[int]):

--- a/src/pyfreedb/row/models.py
+++ b/src/pyfreedb/row/models.py
@@ -37,6 +37,8 @@ class _Field(Generic[T]):
     def __set__(self, obj: Any, value: Optional[T]) -> None:
         self.__ensure_type(value)
         if value is not NotSet:
+            # We need to typecast the value to field's _typ because for number types the value will be returned
+            # as float by Google Sheet's API.
             value = self._typ(value)  # type: ignore [call-arg]
 
         return setattr(obj._data, self._field_name, value)

--- a/src/pyfreedb/row/models.py
+++ b/src/pyfreedb/row/models.py
@@ -1,6 +1,4 @@
 import dataclasses
-from multiprocessing.sharedctypes import Value
-from re import L
 from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union, cast
 
 
@@ -39,7 +37,7 @@ class _Field(Generic[T]):
     def __set__(self, obj: Any, value: Optional[T]) -> None:
         self.__ensure_type(value)
         if value is not NotSet:
-            value = self._typ(value)
+            value = self._typ(value)  # type: ignore [call-arg]
 
         return setattr(obj._data, self._field_name, value)
 
@@ -64,7 +62,6 @@ class _Field(Generic[T]):
             return True
 
         return False
-
 
 
 class IntegerField(_Field[int]):
@@ -159,6 +156,7 @@ class Model(metaclass=_Meta):
 
 def _is_ieee754_safe_integer(value: int) -> bool:
     return -(1 << 53) <= value <= (1 << 53)
+
 
 __pydoc__ = {}
 __pydoc__["StringField"] = StringField.__doc__

--- a/src/pyfreedb/row/models.py
+++ b/src/pyfreedb/row/models.py
@@ -157,7 +157,7 @@ class Model(metaclass=_Meta):
 
 
 def _is_ieee754_safe_integer(value: int) -> bool:
-    return -(1 << 53) <= value <= (1 << 53)
+    return value == int(float(value))
 
 
 __pydoc__ = {}

--- a/src/pyfreedb/row/stmt.py
+++ b/src/pyfreedb/row/stmt.py
@@ -309,7 +309,7 @@ class DeleteStmt(Generic[T]):
         self._store._wrapper.clear(self._store._spreadsheet_id, requests)
 
 
-def _escape_val(val):
+def _escape_val(val: Any) -> Any:
     # When the sheet is created all cells's data format will be set to automatic.
     # All data must be escaped to prevent the data "autocasted" by gsheet to other types since we insert them with
     # USER_ENTERED option.

--- a/tests/integration/test_gsheet_kv_store.py
+++ b/tests/integration/test_gsheet_kv_store.py
@@ -10,7 +10,6 @@ from .conftest import IntegrationTestConfig
 
 @pytest.mark.integration
 def test_gsheet_kv_store_append_mode_integration(config: IntegrationTestConfig) -> None:
-    return
     kv_store = GoogleSheetKVStore(
         config.auth_client,
         spreadsheet_id=config.spreadsheet_id,
@@ -22,7 +21,6 @@ def test_gsheet_kv_store_append_mode_integration(config: IntegrationTestConfig) 
 
 @pytest.mark.integration
 def test_gsheet_kv_store_default_mode_integration(config: IntegrationTestConfig) -> None:
-    return
     kv_store = GoogleSheetKVStore(
         config.auth_client,
         spreadsheet_id=config.spreadsheet_id,

--- a/tests/integration/test_gsheet_kv_store.py
+++ b/tests/integration/test_gsheet_kv_store.py
@@ -10,6 +10,7 @@ from .conftest import IntegrationTestConfig
 
 @pytest.mark.integration
 def test_gsheet_kv_store_append_mode_integration(config: IntegrationTestConfig) -> None:
+    return
     kv_store = GoogleSheetKVStore(
         config.auth_client,
         spreadsheet_id=config.spreadsheet_id,
@@ -21,6 +22,7 @@ def test_gsheet_kv_store_append_mode_integration(config: IntegrationTestConfig) 
 
 @pytest.mark.integration
 def test_gsheet_kv_store_default_mode_integration(config: IntegrationTestConfig) -> None:
+    return
     kv_store = GoogleSheetKVStore(
         config.auth_client,
         spreadsheet_id=config.spreadsheet_id,

--- a/tests/integration/test_gsheet_row_store.py
+++ b/tests/integration/test_gsheet_row_store.py
@@ -1,4 +1,3 @@
-from ast import Mod
 import pytest
 
 from pyfreedb.row import GoogleSheetRowStore, Ordering, models
@@ -82,6 +81,7 @@ class Model(models.Model):
     integer_field = models.IntegerField()
     float_field = models.FloatField()
 
+
 @pytest.mark.integration
 def test_gsheet_row_edge_cases(config: IntegrationTestConfig) -> None:
     row_store = GoogleSheetRowStore(
@@ -100,7 +100,6 @@ def test_gsheet_row_edge_cases(config: IntegrationTestConfig) -> None:
     expected_rows = [
         Model(integer_field=1, float_field=1.0),
         Model(integer_field=9007199254740992, float_field=1.7976931348623157),
-
         # truncated to fit 64-bit floating point.
         Model(integer_field=9007199254740992, float_field=1.797693134862316),
     ]

--- a/tests/integration/test_gsheet_row_store.py
+++ b/tests/integration/test_gsheet_row_store.py
@@ -44,6 +44,13 @@ def test_gsheet_row_store_integration(config: IntegrationTestConfig) -> None:
     rows = row_store.select().where("dob = ?", "1999-01-01").execute()
     assert rows == [Customer(name="name1", age=10, dob="1999-01-01")]
 
+    # Need to check for types during update.
+    try:
+        rows_changed = row_store.update({"name": 4}).where("age = ?", 10).execute()
+        pytest.fail("should raise TypeError")
+    except TypeError:
+        pass
+
     # Update one of the row, expects only 1 rows that changed.
     rows_changed = row_store.update({"name": "name4"}).where("age = ?", 10).execute()
     assert rows_changed == 1

--- a/tests/integration/test_gsheet_row_store.py
+++ b/tests/integration/test_gsheet_row_store.py
@@ -90,6 +90,7 @@ def test_gsheet_row_edge_cases(config: IntegrationTestConfig) -> None:
 
     inserted_rows = [
         Model(integer_field=1, float_field=1.0),
+        # 2^53 and Max. double value.
         Model(integer_field=9007199254740992, float_field=1.7976931348623157),
     ]
     row_store.insert(inserted_rows).execute()

--- a/tests/integration/test_gsheet_row_store.py
+++ b/tests/integration/test_gsheet_row_store.py
@@ -80,7 +80,7 @@ class Model(models.Model):
 
 
 @pytest.mark.integration
-def test_gsheet_row_edge_cases(config: IntegrationTestConfig) -> None:
+def test_gsheet_row_number_boundaries(config: IntegrationTestConfig) -> None:
     row_store = GoogleSheetRowStore(
         config.auth_client,
         spreadsheet_id=config.spreadsheet_id,

--- a/tests/integration/test_gsheet_row_store.py
+++ b/tests/integration/test_gsheet_row_store.py
@@ -27,9 +27,9 @@ def test_gsheet_row_store_integration(config: IntegrationTestConfig) -> GoogleSh
 
     # Insert some data, expects no exception raised.
     rows = [
-        Customer(name="name1", age=10, dob="1-1-1999"),
-        Customer(name="name2", age=11, dob="1-1-2000"),
-        Customer(name="name3", age=12, dob="1-1-2001"),
+        Customer(name="name1", age=10, dob="1999-01-01"),
+        Customer(name="name2", age=11, dob="2000-01-01"),
+        Customer(name="name3", age=12, dob="2001-01-01"),
     ]
     row_store.insert(rows).execute()
 
@@ -41,12 +41,15 @@ def test_gsheet_row_store_integration(config: IntegrationTestConfig) -> GoogleSh
     rows = row_store.select("name", "age").where("age < ? AND age > ?", 12, 10).execute()
     assert rows == [Customer(name="name2", age=11)]
 
+    rows = row_store.select().where("dob = ?", "1999-01-01").execute()
+    assert rows == [Customer(name="name1", age=10, dob="1999-01-01")]
+
     # Update one of the row, expects only 1 rows that changed.
     rows_changed = row_store.update({"name": "name4"}).where("age = ?", 10).execute()
     assert rows_changed == 1
 
     # If no where clause, update all.
-    rows_changed = row_store.update({"dob": "1-1-2002"}).execute()
+    rows_changed = row_store.update({"dob": "2002-01-01"}).execute()
     assert rows_changed == 3
 
     # It should reflect the previous update and return in descending order by age.

--- a/tests/row/test_models.py
+++ b/tests/row/test_models.py
@@ -71,3 +71,18 @@ def test_model_type_check() -> None:
         pytest.fail("should raise TypeError")
     except TypeError:
         pass
+
+def test_boundary() -> None:
+    try:
+        a = A(integer_field=1<<54)
+        pytest.fail("should raise ValueError")
+    except ValueError:
+        pass
+
+
+def test_is_ieee754_safe_integer():
+    assert models._is_ieee754_safe_integer(0)
+    assert models._is_ieee754_safe_integer(-9007199254740992)
+    assert not models._is_ieee754_safe_integer(-9007199254740993)
+    assert models._is_ieee754_safe_integer(9007199254740992)
+    assert not models._is_ieee754_safe_integer(9007199254740993)

--- a/tests/row/test_models.py
+++ b/tests/row/test_models.py
@@ -75,7 +75,7 @@ def test_model_type_check() -> None:
 
 def test_boundary() -> None:
     try:
-        a = A(integer_field=1 << 54)
+        a = A(integer_field=(1 << 54) + 1)
         pytest.fail("should raise ValueError")
     except ValueError:
         pass
@@ -87,3 +87,5 @@ def test_is_ieee754_safe_integer() -> None:
     assert not models._is_ieee754_safe_integer(-9007199254740993)
     assert models._is_ieee754_safe_integer(9007199254740992)
     assert not models._is_ieee754_safe_integer(9007199254740993)
+
+    assert models._is_ieee754_safe_integer(1 << 54)

--- a/tests/row/test_models.py
+++ b/tests/row/test_models.py
@@ -72,15 +72,16 @@ def test_model_type_check() -> None:
     except TypeError:
         pass
 
+
 def test_boundary() -> None:
     try:
-        a = A(integer_field=1<<54)
+        a = A(integer_field=1 << 54)
         pytest.fail("should raise ValueError")
     except ValueError:
         pass
 
 
-def test_is_ieee754_safe_integer():
+def test_is_ieee754_safe_integer() -> None:
     assert models._is_ieee754_safe_integer(0)
     assert models._is_ieee754_safe_integer(-9007199254740992)
     assert not models._is_ieee754_safe_integer(-9007199254740993)


### PR DESCRIPTION
Type: Bug

## Fix automatic typecasting when inserting/updating data to Google Sheet

1. On fresh spreadsheet all cell formatting is set to automatic.
2. when we call `row_store.insert` or `row_store.update` internally we will push the data to google sheet using `USER_ENTERED` mode hence `"1"` will be interpreted as number (`1`) and `"2020-1-1"` as date `Date(2020-01-01)`.
    3. This causes the library to crash when we insert `"1"` as a string and selecting them since GViz API returned it as number instead.

## Fix number precision loss

Previously we use `f` to get the value of a number from GViz API, and it turned out that `f` means "formatted" value a.k.a value that user see from the Google Sheet API. We should use `v` instead which is the true "raw" data.

## Added range check to number type-backed fields (`IntegerField` and `FloatField`)

Google Sheet internally treats `number` as double precision float ([IEEE754](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)) and because of that there will be a precision loss if we break the limit. I added some check for `IntegerField` to ensure it can be exactly stored in GSheet without loss and recommend user to use StringField to store big integers.

## Use Google's `requests` wrapper

Their wrapper will handle the authorization part and will automatically refresh the token when it's expired.