### PR TITLE
Update the requests dependency version requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,6 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 .vscode/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ include = '\.pyi?$'
 strict = true
 ignore_missing_imports = true
 disallow_subclassing_any = false
+disallow_untyped_calls = false
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "google-api-python-client==2.51.0",
     "google-auth-httplib2==0.1.0",
     "google-auth-oauthlib==0.5.2",
-    "requests==2.28.1"
+    "requests>=2.28.1, < 3"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 google-api-python-client==2.51.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.5.2
-requests>=2.28, <3
+requests>=2.30, <3
 black==22.3.0
 mypy==0.961
 isort==5.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 google-api-python-client==2.51.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.5.2
-requests==2.28
+requests>=2.28, <3
 black==22.3.0
 mypy==0.961
 isort==5.10.1

--- a/src/pyfreedb/__init__.py
+++ b/src/pyfreedb/__init__.py
@@ -1,3 +1,3 @@
 """PyFreeDB is a Python library that provides common and simple database abstractions on top of Google Sheets."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/pyfreedb/providers/google/auth/base.py
+++ b/src/pyfreedb/providers/google/auth/base.py
@@ -1,11 +1,12 @@
 import abc
+from typing import Union
 
-from google.oauth2.credentials import Credentials
+from google.oauth2 import credentials, service_account
 
 
 class GoogleAuthClient(abc.ABC):
     """An abstraction layer that represents way to authenticate with Google APIs."""
 
     @abc.abstractmethod
-    def credentials(self) -> Credentials:
+    def credentials(self) -> Union[credentials.Credentials, service_account.Credentials]:
         pass

--- a/src/pyfreedb/providers/google/sheet/wrapper.py
+++ b/src/pyfreedb/providers/google/sheet/wrapper.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Dict, List, Union
 
+import requests
 from google.auth.transport.requests import AuthorizedSession
 from googleapiclient.discovery import build
 
@@ -19,7 +20,7 @@ class _GoogleSheetWrapper:
     def __init__(self, auth_client: GoogleAuthClient):
         service = build("sheets", "v4", credentials=auth_client.credentials())
         self._svc = service.spreadsheets()
-        self._authed_session = AuthorizedSession(auth_client.credentials())
+        self._authed_session: AuthorizedSession = AuthorizedSession(auth_client.credentials())
 
     def create_spreadsheet(self, title: str) -> str:
         resp = self._svc.create(body={"properties": {"title": title}}).execute()
@@ -137,7 +138,7 @@ class _GoogleSheetWrapper:
         }
 
         url = "https://docs.google.com/spreadsheets/d/{}/gviz/tq".format(spreadsheet_id)
-        response = self._authed_session.request(
+        response: requests.Response = self._authed_session.request(
             "GET",
             url,
             headers={"Content-Type": "application/json"},
@@ -148,7 +149,7 @@ class _GoogleSheetWrapper:
 
     def _convert_query_result(self, response: str) -> List[List[Any]]:
         # Remove the schema header -> freeleh({...}).
-        # We only care about the JSON inside of the bracket.
+        # We only care about the JSON inside the bracket.
         start, end = response.index("{"), response.rindex("}")
         resp = json.loads(response[start : end + 1])
         cols = resp["table"]["cols"]


### PR DESCRIPTION
Otherwise when another library requires a higher version of `requests` library, we cannot install the requirements for that project.

Added an exceptional case on `mypy` so that we can call an `untyped` function on a `typed` function scope. We cannot control how other libraries manage their typing.