### PR TITLE
Update the deployment workflow since pdoc does not work with older Python

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ">=3.12, <4.0.0"
 
       - name: Install Flit
         run: pip install flit

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ google-api-python-client==2.51.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.5.2
 requests>=2.30, <3
-black==22.3.0
+black>=24.3.0
 mypy==0.961
 isort==5.10.1
 pytest==7.1.2

--- a/src/pyfreedb/row/models.py
+++ b/src/pyfreedb/row/models.py
@@ -112,7 +112,7 @@ class _Meta(type):
         # Internally, we will store the actual data in a dataclass so that we don't need to deal with the details of
         # how to store the data.
         dataclasses_fields = []
-        for (field_name, field) in fields.items():
+        for field_name, field in fields.items():
             value = dataclasses.field(default=NotSet)
             dataclasses_fields.append((field_name, cast(type, Union[field._typ, NotSet]), value))
 


### PR DESCRIPTION
- Update `black` version due to dependabot potential security issue.
- Use latest Python to run `publish` workflow due to `pdoc` newer version requires newer version of Python as well.